### PR TITLE
Preserve dotenv-extended behavior

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const dotenv = require('dotenv-extended');
 const fs = require('fs');
-const DefinePlugin = require('webpack').DefinePlugin;
+const EnvironmentPlugin = require('webpack').EnvironmentPlugin;
 
 module.exports = DotenvPlugin;
 
@@ -13,19 +13,17 @@ function DotenvPlugin(options) {
 }
 
 DotenvPlugin.prototype.apply = function(compiler) {
-  const definitions = {};
-
-  Object.keys(process.env).forEach((key) => {
-    if (this.config.hasOwnProperty(key)) {
-      definitions[key] = JSON.stringify(process.env[key]);
-    }
-  });
-
   if (this.options.verbose) {
+    const definitions = {};
+
+    Object.keys(this.config).forEach((key) => {
+      if (this.config.hasOwnProperty(key)) {
+        definitions[key] = process.env[key];
+      }
+    });
+
     console.log('Applying dotenv configuration', JSON.stringify(definitions, null, 2));
   }
 
-  compiler.apply(new DefinePlugin({
-    'process.env': definitions
-  }));
+  compiler.apply(new EnvironmentPlugin(Object.keys(this.config)));
 };

--- a/index.js
+++ b/index.js
@@ -7,14 +7,14 @@ module.exports = DotenvPlugin;
 function DotenvPlugin(options) {
   // Load into process.env, and keep track of all the
   // keys we care about for webpack serialization. 
-  this.config = dotenv.load(options);
+  this.config = dotenv.load(options) || {};
 }
 
 DotenvPlugin.prototype.apply = function(compiler) {
   const definitions = {};
 
-  Object.keys(this.definitions).forEach((key) => {
-    if (this.config[key]) {
+  Object.keys(process.env).forEach((key) => {
+    if (this.config.hasOwnProperty(key)) {
       definitions[key] = JSON.stringify(process.env[key]);
     }
   });

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const DefinePlugin = require('webpack').DefinePlugin;
 module.exports = DotenvPlugin;
 
 function DotenvPlugin(options) {
-  dotenv.load(options);
+  this.definitions = dotenv.load(options);
 }
 
 DotenvPlugin.prototype.apply = function(compiler) {

--- a/index.js
+++ b/index.js
@@ -5,47 +5,17 @@ const DefinePlugin = require('webpack').DefinePlugin;
 module.exports = DotenvPlugin;
 
 function DotenvPlugin(options) {
-  options = options || {};
-  if (!options.defaults) options.defaults = './.env.defaults';
-  if (!options.schema) options.schema = './.env.schema';
-  if (!options.path) options.path = './.env';
-
   dotenv.load(options);
-
-  this.defaults = dotenv.parse(fs.readFileSync(options.defaults));
-  this.schema = dotenv.parse(fs.readFileSync(options.schema));
-  this.env = {};
-  if (fs.existsSync(options.path)) {
-    this.env = dotenv.parse(fs.readFileSync(options.path));
-  }
 }
 
 DotenvPlugin.prototype.apply = function(compiler) {
-  const definitions = Object.keys(this.schema).reduce((definitions, key) => {
-    const existing = process.env[key];
+  const definitions = {};
 
-    if (existing) {
-      definitions[key] = JSON.stringify(existing);
-      return definitions;
-    }
-
-    const value = this.env[key];
-    if (value) definitions[key] = JSON.stringify(value);
-
-    return definitions;
-  }, {});
-
-  const definitionsWithDefaults = Object.keys(this.defaults).reduce((definitions, key) => {
-    const definedValue = definitions[key];
-
-    if (!definedValue) {
-      definitions[key] = JSON.stringify(this.defaults[key]);
-    }
-
-    return definitions;
-  }, definitions);
+  Object.keys(this.definitions).forEach((key) => {
+    definitions[key] = JSON.stringify(this.definitions[key]);
+  });
 
   compiler.apply(new DefinePlugin({
-      'process.env': definitionsWithDefaults,
+      'process.env': definitions
   }));
 };

--- a/index.js
+++ b/index.js
@@ -5,6 +5,8 @@ const DefinePlugin = require('webpack').DefinePlugin;
 module.exports = DotenvPlugin;
 
 function DotenvPlugin(options) {
+  this.options = options || {};
+
   // Load into process.env, and keep track of all the
   // keys we care about for webpack serialization. 
   this.config = dotenv.load(options) || {};
@@ -18,6 +20,10 @@ DotenvPlugin.prototype.apply = function(compiler) {
       definitions[key] = JSON.stringify(process.env[key]);
     }
   });
+
+  if (this.options.verbose) {
+    console.log('Applying dotenv configuration', JSON.stringify(definitions, null, 2));
+  }
 
   compiler.apply(new DefinePlugin({
     'process.env': definitions

--- a/index.js
+++ b/index.js
@@ -5,17 +5,21 @@ const DefinePlugin = require('webpack').DefinePlugin;
 module.exports = DotenvPlugin;
 
 function DotenvPlugin(options) {
-  this.definitions = dotenv.load(options);
+  // Load into process.env, and keep track of all the
+  // keys we care about for webpack serialization. 
+  this.config = dotenv.load(options);
 }
 
 DotenvPlugin.prototype.apply = function(compiler) {
   const definitions = {};
 
   Object.keys(this.definitions).forEach((key) => {
-    definitions[key] = JSON.stringify(this.definitions[key]);
+    if (this.config[key]) {
+      definitions[key] = JSON.stringify(process.env[key]);
+    }
   });
 
   compiler.apply(new DefinePlugin({
-      'process.env': definitions
+    'process.env': definitions
   }));
 };


### PR DESCRIPTION
By deep-calling into `dotenv`, some less common behaviors are broken. In one example, a `.env` file with an empty variable (e.g., `FOO=`) does not override a default (`FOO=123`).

I propose it's simpler to just let dotenv handle all the magic by making this a thin wrapper with your stringify magic.